### PR TITLE
Set version explicitly during build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,12 @@ source:
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
+  build:
+    script_env:
+      VERSION={{ version }}
   host:
     - python {{ python_min }}
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,10 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   noarch: python
   number: 1
+  script_env:
+    - VERSION={{ version }}
 
 requirements:
-  build:
-    script_env:
-      - VERSION={{ version }}
   host:
     - python {{ python_min }}
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
 requirements:
   build:
     script_env:
-      VERSION={{ version }}
+      - VERSION={{ version }}
   host:
     - python {{ python_min }}
     - pip


### PR DESCRIPTION
The `setup.py` has the following:

```python
__version__ = os.getenv("VERSION") or "0.0.0+develop"
```

This does not get set properly when installing.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
