### PR TITLE
lyteidl 0.3.1: regenerated protobuf bindings, drop py3.11 cap

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "lyteidl" %}
-{% set version = "0.2.1" %}
-{% set python_max = "3.11" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -8,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/lyteidl-{{ version }}.tar.gz
-  sha256: 9c5ebe96615e4fd03dd393c49f6356285be8e3860c58271ac7c8babc170165a8
+  sha256: 23202773d76e734929bfe9767cbf22f33db903b8a23a22e9be759c6afb932be9
 
 build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   noarch: python
-  number: 1
+  number: 0
   script_env:
     - VERSION={{ version }}
 
@@ -23,10 +22,10 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >={{ python_min }},<={{ python_max }}
+    - python >={{ python_min }}
     - googleapis-common-protos
     - protoc-gen-swagger
-    - protobuf >=3.5.0,<4.0.0
+    - protobuf >=3.20.3,<6
 
 test:
   imports:


### PR DESCRIPTION
## Summary

Bump `lyteidl` 0.2.1 → 0.3.1, the first upstream release whose generated `_pb2.py` files are regenerated with `protoc >= 3.19`. This enables installation on Python 3.12 with `protobuf >= 4`.

- Drop the `python_max = "3.11"` cap. Upstream supports through 3.12.
- Relax `protobuf >=3.5.0,<4.0.0` → `>=3.20.3,<6` to match upstream's `pyproject.toml`.
- Reset `build.number` to 0 for the version bump.

Background: latchbio/latch#589. The 0.2.1 sdist's `_pb2.py` files use the pre-3.19 descriptor pattern, which isn't compatible with `protobuf 4+`; the 0.3.1 release regenerates them.

Opening this alongside the existing autotick PRs (#4, #5) since the version bump alone isn't sufficient — the python cap and protobuf pin also need to move.

## Test plan

- conda-build succeeds on the configured matrix, including py3.12.
- `from flyteidl.core import literals_pb2` imports cleanly under `protobuf 5.29` on py3.12.
- `pip check` in the existing test stanza passes.